### PR TITLE
Global search url for resource overview

### DIFF
--- a/invenio_override/templates/invenio_override/resource_overview.html
+++ b/invenio_override/templates/invenio_override/resource_overview.html
@@ -19,7 +19,7 @@
           </div>
           <ul>
             <li>
-              <a href="records/search">{{ _("Search for research results") }}</a>
+              <a href="{{ url_for('invenio_search_ui.search') }}">{{ _("Search for research results") }}</a>
             </li>
             <li>
               <a href="me/uploads">{{ _("Upload research results") }}</a>
@@ -39,7 +39,7 @@
           </div>
           <ul>
             <li>
-              <a href="publications/search">{{ _("Search for publications") }}</a>
+              <a href="{{ url_for('invenio_search_ui.search') }}">{{ _("Search for publications") }}</a>
             </li>
           </ul>
         </div>
@@ -57,10 +57,10 @@
           </div>
           <ul>
             <li>
-              <a href="oer/search">{{ _("Search for educational resources") }}</a>
+              <a href="{{ url_for('invenio_search_ui.search') }}">{{ _("Search for educational resources") }}</a>
             </li>
             <li>
-              <a href="oer/uploads">{{ _("Upload educational resources") }}</a>
+              <a href="{{ url_for('invenio_search_ui.search') }}">{{ _("Upload educational resources") }}</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
### Summary
This PR implements temporary routing for all “Browse” links to the general search page in InvenioRDM. 

### Details
- Updated `generate_search_url` to handle general queries.
- All URL links currently redirect to `/search?q=&page=1&size=10`.


### Next Steps
- Investigate and implement routing for specific categories (e.g., publications, research results).


