### PR TITLE
fix: rename Uploads menu to Research Results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
 
 .. image:: https://readthedocs.org/projects/invenio-override/badge/?version=latest
         :target: https://invenio-override.readthedocs.io/en/latest/?badge=latest
-        
+
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
@@ -77,7 +77,7 @@ Enabling the OVERRIDE configurations without their respective library might lead
     OVERRIDE_RESOURCE_OVERVIEW = False
 
     # Enable or disable the right section of the frontpage (Contact us, Benefits)
-    OVERRIDE_FRONTPAGE_RIGHT = False 
+    OVERRIDE_FRONTPAGE_RIGHT = False
 
     # If section Benefits is displayed, option to click on More and go to Statistics page for more info
     OVERRIDE_RIGHT_SECTION_TITLE = True
@@ -105,13 +105,21 @@ Enabling the OVERRIDE configurations without their respective library might lead
     # list of available options: ["kfu.ico", "mug.ico", "tug.ico"]
     OVERRIDE_FAVICON = "favicon.ico"
 
+    # Override the Uploads menu title
+    USER_DASHBOARD_MENU_OVERRIDES = {
+      "uploads": {
+        "text": _("Research Results"),
+      },
+    }
+
+
 * Differentiate between production and testing instance
 
 .. code-block:: python
 
     # Production environment. Can also be set in .env as 'INVENIO_OVERRIDE_PRODUCTION'
-    OVERRIDE_PRODUCTION = False 
-    
+    OVERRIDE_PRODUCTION = False
+
 
 Further documentation is available on
 https://invenio-override.readthedocs.io/

--- a/invenio_override/ext.py
+++ b/invenio_override/ext.py
@@ -66,7 +66,6 @@ def modify_user_dashboard(app):
     """
     root_menu = app.extensions["menu"].root_node
     user_dashboard_menu = root_menu.submenu("dashboard")
-    user_dashboard_menu.submenu("uploads")._text = text = "Research Results"
 
     if "overview" not in user_dashboard_menu.children:
         user_dashboard_menu.submenu("overview").register(


### PR DESCRIPTION
- remove renaming from ext.py, delegate it to instance config
- update docs
- linked PR in instance: https://github.com/sharedRDM/instance/pull/33