### PR TITLE
feat: imp file access restriction display in marc21 record page

### DIFF
--- a/invenio_override/permissions.py
+++ b/invenio_override/permissions.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Shared RDM.
+#
+# invenio-override is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Custom permissions for the Invenio Override module."""
+
+from invenio_records_marc21.services.permissions import Marc21RecordPermissionPolicy
+from invenio_records_permissions.generators import (
+    AnyUser,
+    AuthenticatedUser,
+    SystemProcess,
+)
+
+
+class LenientMarc21PermissionPolicy(Marc21RecordPermissionPolicy):
+    """A more lenient policy allowing read access to restricted metadata and files for authenticated users."""
+
+    # Allow anyone (including anonymous users) to read the metadata of any record,
+    # even if the record itself is restricted. File access is handled separately.
+    can_read = [AnyUser(), SystemProcess()]
+
+    # Allow authenticated users to read restricted files
+    can_read_files = [AuthenticatedUser(), SystemProcess()]
+
+    # Keep other permissions potentially strict (like the default)
+    # For example, file access might still require specific permissions
+    can_create = Marc21RecordPermissionPolicy.can_create
+    can_update = Marc21RecordPermissionPolicy.can_update
+    can_delete = Marc21RecordPermissionPolicy.can_delete
+    # Add other 'can_*' attributes as needed, inheriting from the base policy
+
+    # If you need draft permissions:
+    # can_edit = Marc21RecordPermissionPolicy.can_edit
+    # can_new_version = Marc21RecordPermissionPolicy.can_new_version
+    # can_manage = Marc21RecordPermissionPolicy.can_manage
+    # can_update_draft = Marc21RecordPermissionPolicy.can_update_draft
+    # can_read_draft = Marc21RecordPermissionPolicy.can_read_draft
+    # can_delete_draft = Marc21RecordPermissionPolicy.can_delete_draft

--- a/invenio_override/templates/invenio_records_marc21/landing_page/record.html
+++ b/invenio_override/templates/invenio_records_marc21/landing_page/record.html
@@ -1,0 +1,107 @@
+{#
+This file is part of Invenio.
+
+Copyright (C) 2021-2024 Graz University of Technology.
+
+Invenio-Records-Marc21 is free software; you can redistribute it and/or
+modify it under the terms of the MIT License; see LICENSE file for more
+details.
+#}
+
+{%- extends config.MARC21_BASE_TEMPLATE %}
+
+
+{%- from "invenio_records_marc21/landing_page/macros/detail.html" import record_detail %}
+
+{%- set metadata = record.ui.metadata %}
+
+{% block head_title %}
+<title>
+  {% for title in metadata.get('titles') %}
+    {{title}}
+  {% endfor %}
+</title>
+{% endblock head_title %}
+{%- block page_body %}
+
+<div class="ui container" id="marc21-landing-page">
+  <div class="ui relaxed grid mt-5">
+    <div class="two column row top-padded">
+      <article class="sixteen wide tablet eleven wide computer column main-record-content">
+        {%- block record_body %}
+
+        {%- block record_header -%}
+
+        <div class="ui grid middle aligned">
+          <div class="two column row">
+            <div class="left floated left aligned column">
+              <div class="twelve wide column">
+                <span class="ui" title="{{_('Published date')}}">
+                  {{ _("Published in") }} {{ metadata.published }}
+                </span>
+                {%- if record.ui.version %}
+                <span class="label text-muted"> | Version {{ record.ui.version }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <div class="right floated right aligned column">
+              {% if metadata.resource_type %}
+              <span class="ui label small neutral" title="{{ _('Resource type') }}">{{ metadata.resource_type
+                }}</span>
+              {% endif %}
+              <span class="ui label small access-status {{ record.ui.access_status.id }}"
+                title="{{ _('Access status') }}" data-tooltip="{{ record.ui.access_status.description_l10n }}"
+                data-inverted="">
+                {% if record.ui.access_status.icon %}
+                <i class="icon {{ record.ui.access_status.icon }}"></i>
+                {% endif %}
+                {{ record.ui.access_status.title_l10n }}
+              </span>
+            </div>
+          </div>
+        </div>
+        {%- endblock record_header -%}
+
+        {%- block record_title -%}
+        <div class="ui divider hidden"></div>
+        {%- include "invenio_records_marc21/landing_page/helpers/title.html" %}
+        {%- endblock record_title -%}
+
+        {% if not current_user.is_authenticated and record.access.record == "restricted" and not can_view_marc21 %}
+          <div class="ui negative message">
+            <div class="header">Access Restricted</div>
+            <p>This record is restricted. Please <a href="{{ url_for('security.login', next=request.path) }}">log in</a> to view its contents.</p>
+          </div>
+        {% else %}
+          {%- block record_files -%}
+          <div class="top-padded"></div>
+          <hr class="thin-line">
+          {% if record.access.files == "restricted" and not can_view_marc21 %}
+            <div class="ui negative message">
+              <div class="header">Restricted</div>
+              <p>The record is publicly accessible, but files are restricted to users with access.</p>
+            </div>
+          {% endif %}
+          {%- include "invenio_records_marc21/landing_page/helpers/files.html" %}
+          {%- endblock record_files -%}
+
+          {%- block record_footer -%}
+          {%- include "invenio_records_marc21/landing_page/helpers/footer.html" %}
+          {%- endblock record_footer -%}
+        {% endif %}
+        {%- endblock record_body %}
+      </article>
+
+      {% block record_sidebar %}
+      {%- include "invenio_records_marc21/landing_page/helpers/side_bar.html" %}
+      {% endblock record_sidebar %}
+    </div>
+  </div>
+</div>
+{%- endblock page_body %}
+
+
+{%- block javascript %}
+{{ super() }}
+{{ webpack["invenio-records-marc21-landing-page.js"] }}
+{%- endblock javascript %}

--- a/invenio_override/views.py
+++ b/invenio_override/views.py
@@ -12,7 +12,14 @@
 from functools import wraps
 from typing import Dict, Optional
 
-from flask import Blueprint, current_app, g, redirect, render_template, url_for
+from flask import (
+    Blueprint,
+    current_app,
+    g,
+    redirect,
+    render_template,
+    url_for,
+)
 from flask_login import current_user, login_required
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
@@ -72,16 +79,6 @@ def index():
     )
 
 
-def default_error_handler(e: Exception) -> tuple:
-    """
-    Handle unhandled errors.
-
-    :param e: Exception raised.
-    :returns: Rendered error page with HTTP 500 status.
-    """
-    return render_template(current_app.config["THEME_500_TEMPLATE"]), 500
-
-
 @blueprint.app_template_filter("make_dict_like")
 def make_dict_like(value: str, key: str) -> Dict[str, str]:
     """
@@ -105,13 +102,8 @@ def cast_to_dict(attr_dict: AttrDict) -> dict:
     return AttrDict.to_dict(attr_dict)
 
 
-def ui_blueprint(app) -> Blueprint:
-    """
-    Create a UI blueprint for routes and resources.
-
-    :param app: Flask app instance.
-    :returns: Configured blueprint.
-    """
+def ui_blueprint(app):
+    """Register UI blueprint and error handlers."""
     routes = app.config.get("OVERRIDE_ROUTES")
     blueprint.add_url_rule(routes["index"], view_func=index)
     return blueprint


### PR DESCRIPTION
created `invenio_override/permissions.py` with a `LenientMarc21PermissionPolicy` where the policy allows `AnyUser` to read record metadata (`can_read`) but restricts file reading (`can_read_files`) to `AuthenticatedUser`.

- updated `invenio_override/ext.py` to import and apply the `LenientMarc21PermissionPolicy` via `app.config["MARC21_PERMISSION_POLICY"]`. 
- removed the custom `handle_permission_denied` error handler from `invenio_override/views.py` and its registration. 
- relied on the existing template override `invenio_override/templates/invenio_records_marc21/landing_page/record.html` and its conditional block (`{% if record.access.files == "restricted" and not can_view_marc21 %}`) to display the restriction message.


