### PR TITLE
ui: tailor navbar/frontpage to Research Results

### DIFF
--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -41,6 +41,9 @@ OVERRIDE_SHOW_PUBLICATIONS_SEARCH = False
 OVERRIDE_SHOW_EDUCATIONAL_RESOURCES = False
 """Enable or disable the educational resources global search feature."""
 
+OVERRIDE_SHOW_RDM_SEARCH = False
+"""Force UI to show only Research Results (RDM) in search/overview components."""
+
 RDM_RECORDS_SERVICE_COMPONENTS = RDMDefaultRecordsComponents + [
     RDMToGlobalSearchComponent
 ]

--- a/invenio_override/templates/invenio_override/navbar.html
+++ b/invenio_override/templates/invenio_override/navbar.html
@@ -7,49 +7,12 @@
   details.
 #}
 
-{% set options = [] %}
-
-{# Ensure at least one default option exists #}
-{% set base_option = {
+{% set options = [{
     "key": "rdm",
     "text": "Research Results",
     "value": "/records/search",
     "title": "Research Data",
-} %}
-{% set options = options + [base_option] %}
-
-{% if config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH %}
-    {% set pub_option = {
-        "key": "marc21",
-        "text": "Publications",
-        "value": url_for("invenio_records_marc21.search"),
-        "title": "Publication",
-    } %}
-    {% set options = options + [pub_option] %}
-{% endif %}
-
-{% if config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES %}
-    {% set edu_option = {
-        "key": "lom",
-        "text": "Educational Resources",
-        "value": url_for("invenio_records_lom.search"),
-        "title": "OER",
-    } %}
-    {% set options = options + [edu_option] %}
-{% endif %}
-
-{% if options | length > 1 %}
-    {% set all_option = {
-        "key": "records",
-        "text": "All",
-        "value": url_for("invenio_search_ui.search"),
-        "title": "repo",
-    } %}
-    {% set options = [all_option] + options %}
-{% endif %}
-
-{# Ensure options is not None or Undefined #}
-{% set options_json = options | tojson if options is not none else "[]" %}
+}] %}
 
 <div class="ui container">
   <div class="short-menu" id="all-menu-top-table">

--- a/invenio_override/templates/invenio_override/navbar.html
+++ b/invenio_override/templates/invenio_override/navbar.html
@@ -7,12 +7,50 @@
   details.
 #}
 
-{% set options = [{
+{% set options = [] %}
+{% set only_rdm = config.OVERRIDE_SHOW_RDM_SEARCH %}
+
+{# Ensure at least one default option exists #}
+{% set base_option = {
     "key": "rdm",
     "text": "Research Results",
     "value": "/records/search",
     "title": "Research Data",
-}] %}
+} %}
+{% set options = options + [base_option] %}
+
+{% if config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH and not only_rdm %}
+    {% set pub_option = {
+        "key": "marc21",
+        "text": "Publications",
+        "value": url_for("invenio_records_marc21.search"),
+        "title": "Publication",
+    } %}
+    {% set options = options + [pub_option] %}
+{% endif %}
+
+{% if config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES and not only_rdm %}
+    {% set edu_option = {
+        "key": "lom",
+        "text": "Educational Resources",
+        "value": url_for("invenio_records_lom.search"),
+        "title": "OER",
+    } %}
+    {% set options = options + [edu_option] %}
+{% endif %}
+
+{% if options | length > 1 %}
+    {% set all_option = {
+        "key": "records",
+        "text": "All",
+        "value": url_for("invenio_search_ui.search"),
+        "title": "repo",
+    } %}
+    {% set options = [all_option] + options %}
+{% endif %}
+
+{# Ensure options is not None or Undefined #}
+{% set options_json = options | tojson if options is not none else "[]" %}
 
 <div class="ui container">
   <div class="short-menu" id="all-menu-top-table">
@@ -23,7 +61,7 @@
       <div class="right menu">
         <div class="item">
           <div class="ui icon input">
-            <div id="header-search-bar" data-options='{{ options | tojson }}'></div>
+            <div id="header-search-bar" data-options='{{ options_json }}'></div>
           </div>
         </div>
         {%- block navbar_right %}

--- a/invenio_override/templates/invenio_override/recent_uploads.html
+++ b/invenio_override/templates/invenio_override/recent_uploads.html
@@ -13,17 +13,12 @@
   {% if not records %}
     <div class="ui centered grid">
       <p style="font-size: medium;">
-  {% if not config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH or not config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES %}
-      {{ _("Explore Research Results available in the repository.") }}
-        {% else %}
-          {{ _("There are no public records to show.") }}
-        {% endif %}
+        {{ _("Explore Research Results available in the repository.") }}
       </p>
     </div>
   {% endif %}
 
   {%- for r in records %}
-    {%- set creation_date = r.created | from_isodatetime -%}
     {%- set record_url = r.original.view %}
 
     <article>
@@ -45,10 +40,6 @@
               data-inverted="">
           <i class="icon {{ r.access_status.icon }}"></i>
           {{ r.access_status.title_l10n }}
-        </span>
-
-        <span class="ui label schema" data-tooltip="Schema Type" data-inverted="">
-          {{ r.original.schema_l10n }}
         </span>
       </div>
 

--- a/invenio_override/templates/invenio_override/recent_uploads.html
+++ b/invenio_override/templates/invenio_override/recent_uploads.html
@@ -13,12 +13,17 @@
   {% if not records %}
     <div class="ui centered grid">
       <p style="font-size: medium;">
-        {{ _("Explore Research Results available in the repository.") }}
+  {% if config.OVERRIDE_SHOW_RDM_SEARCH or (not config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH or not config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES) %}
+      {{ _("Explore Research Results available in the repository.") }}
+        {% else %}
+          {{ _("There are no public records to show.") }}
+        {% endif %}
       </p>
     </div>
   {% endif %}
 
   {%- for r in records %}
+    {%- set creation_date = r.created | from_isodatetime -%}
     {%- set record_url = r.original.view %}
 
     <article>
@@ -41,6 +46,12 @@
           <i class="icon {{ r.access_status.icon }}"></i>
           {{ r.access_status.title_l10n }}
         </span>
+
+        {%- if not config.OVERRIDE_SHOW_RDM_SEARCH %}
+        <span class="ui label schema" data-tooltip="Schema Type" data-inverted="">
+          {{ r.original.schema_l10n }}
+        </span>
+        {%- endif %}
       </div>
 
       <h4>

--- a/invenio_override/templates/invenio_override/resource_overview.html
+++ b/invenio_override/templates/invenio_override/resource_overview.html
@@ -1,19 +1,54 @@
 {# This file contains the resource overview block content. #}
 
-<div class="ui container">
-  <div class="ui divider hidden"></div>
-  <div class="sixteen wide column random-records-frontpage">
-    <div class="center aligned ui equal height stretched grid resource-container resource-columns-1">
-      <div class="left aligned column">
-        <div class="ui segment image">
-          <h2>{{ _("Research Results") }}</h2>
-          <p>{{ _("Research results is the collective term for all the results of a research project. They describe the data, source code and all digital objects on which publication results are based. These include the tools used to collect and process the research data. The following links offer the possibility to add research results to the repository, but also to search for the results of other people.") }}</p>
-          <ul>
-            <li><a href="records/search">{{ _("Search for research results") }}</a></li>
-            <li><a href="me/uploads">{{ _("Upload research results") }}</a></li>
-          </ul>
+{% set only_rdm = config.OVERRIDE_SHOW_RDM_SEARCH %}
+{% set show_publications = config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH and not only_rdm %}
+{% set show_educational = config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES and not only_rdm %}
+
+{% set active_sections = [show_publications, show_educational] | select | list %}
+{% set columns = active_sections | length + 1 %} {# +1 for Research Results, always shown #}
+
+{% if columns > 0 %}
+  <div class="ui container">
+    <div class="ui divider hidden"></div>
+    <div class="sixteen wide column random-records-frontpage">
+    <div class="center aligned ui equal height stretched grid resource-container resource-columns-{{ columns }}">
+
+        <div class="left aligned column">
+          <div class="ui segment image">
+            <h2>{{ _("Research Results") }}</h2>
+            <p>{{_("Research results is the collective term for all the results of a research project. They describe the data, source code and all digital objects on which publication results are based. These include the tools used to collect and process the research data. The following links offer the possibility to add research results to the repository, but also to search for the results of other people.")}}</p>
+            <ul>
+              <li><a href="records/search">{{ _("Search for research results") }}</a></li>
+              <li><a href="me/uploads">{{ _("Upload research results") }}</a></li>
+            </ul>
+          </div>
         </div>
+
+        {%- if show_publications %}
+        <div class="left aligned column">
+          <div class="ui segment image">
+            <h2>{{ _("Publications") }}</h2>
+            <p>{{_("The section of publications covers citations from several areas. Open Access papers are imported from Pure. Publications from Open Access publishers are shared. Digital copies are offered. University publications are made available to a wide range of people. The following link offers the possibility to search among publications.")}}</p>
+            <ul>
+              <li><a href="publications/search">{{ _("Search for publications") }}</a></li>
+            </ul>
+          </div>
+        </div>
+        {%- endif %}
+
+        {%- if show_educational %}
+        <div class="left aligned column">
+          <div class="ui segment image">
+            <h2>{{ _("Educational Resources") }}</h2>
+              <p>{{ _("In this area, you can upload your openly licensed educational content (OER, Open Educational Resources) and search for educational resources uploaded by others. Your uploaded content will be automatically transferred to the <a href=\"https://oerhub.at/en\" target=\"_blank\">OERhub.at</a>. To upload something in this area, an OER certificate and activation of your account is required.") | safe }}</p>
+            <ul>
+              <li><a href="oer/search">{{ _("Search for educational resources") }}</a></li>
+              <li><a href="oer/uploads">{{ _("Upload educational resources") }}</a></li>
+            </ul>
+          </div>
+        </div>
+        {%- endif %}
       </div>
     </div>
   </div>
-</div>
+{% endif %}

--- a/invenio_override/templates/invenio_override/resource_overview.html
+++ b/invenio_override/templates/invenio_override/resource_overview.html
@@ -1,51 +1,19 @@
 {# This file contains the resource overview block content. #}
 
-{% set show_publications = config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH %}
-{% set show_educational = config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES %}
-
-{% set active_sections = [show_publications, show_educational] | select | list %}
-{% set columns = active_sections | length + 1 %} {# +1 for Research Results, always shown #}
-
-{% if columns > 0 %}
-  <div class="ui container">
-    <div class="ui divider hidden"></div>
-    <div class="sixteen wide column random-records-frontpage">
-    <div class="center aligned ui equal height stretched grid resource-container resource-columns-{{ columns }}">
-
-        <div class="left aligned column">
-          <div class="ui segment image">
-            <h2>{{ _("Research Results") }}</h2>
-            <p>{{_("Research results is the collective term for all the results of a research project. They describe the data, source code and all digital objects on which publication results are based. These include the tools used to collect and process the research data. The following links offer the possibility to add research results to the repository, but also to search for the results of other people.")}}</p>
-            <ul>
-              <li><a href="records/search">{{ _("Search for research results") }}</a></li>
-              <li><a href="me/uploads">{{ _("Upload research results") }}</a></li>
-            </ul>
-          </div>
+<div class="ui container">
+  <div class="ui divider hidden"></div>
+  <div class="sixteen wide column random-records-frontpage">
+    <div class="center aligned ui equal height stretched grid resource-container resource-columns-1">
+      <div class="left aligned column">
+        <div class="ui segment image">
+          <h2>{{ _("Research Results") }}</h2>
+          <p>{{ _("Research results is the collective term for all the results of a research project. They describe the data, source code and all digital objects on which publication results are based. These include the tools used to collect and process the research data. The following links offer the possibility to add research results to the repository, but also to search for the results of other people.") }}</p>
+          <ul>
+            <li><a href="records/search">{{ _("Search for research results") }}</a></li>
+            <li><a href="me/uploads">{{ _("Upload research results") }}</a></li>
+          </ul>
         </div>
-
-        {%- if show_publications %}
-        <div class="left aligned column">
-          <div class="ui segment image">
-            <h2>{{ _("Publications") }}</h2>
-            <p>{{_("The section of publications covers citations from several areas. Open Access papers are imported from Pure. Publications from Open Access publishers are shared. Digital copies are offered. University publications are made available to a wide range of people. The following link offers the possibility to search among publications.")}}</p>
-            <ul>
-              <li><a href="publications/search">{{ _("Search for publications") }}</a></li>
-            </ul>
-          </div>
-        </div>
-        {%- endif %}
-
-        {%- if show_educational %}
-        <div class="left aligned column">
-          <div class="ui segment image">
-            <h2>{{ _("Educational Resources") }}</h2>
-              <p>{{ _("In this area, you can upload your openly licensed educational content (OER, Open Educational Resources) and search for educational resources uploaded by others. Your uploaded content will be automatically transferred to the <a href=\"https://oerhub.at/en\" target=\"_blank\">OERhub.at</a>. To upload something in this area, an OER certificate and activation of your account is required.") | safe }}</p>              <li><a href="oer/search">{{ _("Search for educational resources") }}</a></li>
-              <li><a href="oer/uploads">{{ _("Upload educational resources") }}</a></li>
-            </ul>
-          </div>
-        </div>
-        {%- endif %}
       </div>
     </div>
   </div>
-{% endif %}
+</div>


### PR DESCRIPTION
“Research Results only” case all three template files are actively used, and they each cover a different part
navbar:

- It is included by invenio_override/header.html (and also accounts_base.html).
- It defines the header search dropdown options (currently only “Research Results”) via data-options

recent_upload:

- invenio_override/frontpage.html includes it always

resource_overview— Optional only needed if we enable it

- It is only included if config.OVERRIDE_RESOURCE_OVERVIEW is True. For now this is not active. 