### PR TITLE
fix: rename RDM components config

### DIFF
--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -8,6 +8,7 @@
 # details.
 
 """invenio module for sharedRDM theme."""
+
 from invenio_global_search.components import (
     LOMToGlobalSearchComponent,
     Marc21ToGlobalSearchComponent,

--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -44,7 +44,7 @@ OVERRIDE_SHOW_EDUCATIONAL_RESOURCES = False
 OVERRIDE_SHOW_RDM_SEARCH = False
 """Force UI to show only Research Results (RDM) in search/overview components."""
 
-RDM_RECORDS_SERVICE_COMPONENTS = RDMDefaultRecordsComponents + [
+OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS = RDMDefaultRecordsComponents + [
     RDMToGlobalSearchComponent
 ]
 

--- a/invenio_override/generators.py
+++ b/invenio_override/generators.py
@@ -20,6 +20,7 @@ class CommunityCreator(Generator):
     """
 
     def needs(self, record=None, **kwargs):
+        """Override needs."""
         roles = current_app.config.get(
             "OVERRIDE_COMMUNITIES_CREATE_ROLES", ["community-creator"]
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,8 @@ install_requires =
     opensearch-dsl>=2.0.0,<3.0.0
     opensearch-py>=2.0.0,<3.0.0
     invenio-global-search>=0.3.0
-    invenio-rdm-records >=18.0.0
-    invenio-app-rdm[opensearch2]>=13.0.0b3.dev2,<13.1.dev0
+    invenio-rdm-records >=19.0.0
+    invenio-app-rdm[opensearch2]>=13.0.0b3.dev2,<14.0.0
 
 [options.extras_require]
 lom =
@@ -51,10 +51,11 @@ marc21 =
 tests =
     invenio-app>=2.1.0,<3.0.0
     invenio-previewer>=2.2.0
-    pytest-black-ng>=0.4.0
+    pytest-black>=0.6.0
     invenio-global-search[lom, marc21]>=0.3.0
     pytest-invenio>=3.3.0,<4.0.0
-    Sphinx>=4.5.0
+    sphinx>=4.5.0
+    setuptools <82
 opensearch2 =
     invenio-search[opensearch2]>=3.0.0,<4.0.0
     


### PR DESCRIPTION
* the RDM_RECORDS_SERVICE_COMPONENTS is a global core config and can be overwritten by instances using invenio-override rename this with OVERRIDE_ prefix so that users should import it and add it to the other components