### PR TITLE
Add Error Page Template

### DIFF
--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -200,6 +200,12 @@ OVERRIDE_SHIBBOLETH = False
 # See https://invenio-theme.readthedocs.io/en/latest/configuration.html
 # ============================================================================
 
+OVERRIDE_SUPPORT_EMAIL = ""
+"""Support email shown on the error page. Empty string hides the contact link."""
+
+THEME_500_TEMPLATE = "invenio_override/default_error.html"
+"""Template used for unhandled server errors."""
+
 THEME_SEARCHBAR = False
 """Enable or disable the header search bar."""
 

--- a/invenio_override/ext.py
+++ b/invenio_override/ext.py
@@ -19,7 +19,14 @@ except (ImportError, AttributeError):
     current_identity_can_view = lambda: False
 
 from . import config
-from .views import blueprint, index, locked, make_redirect, require_authenticated
+from .views import (
+    blueprint,
+    default_error_handler,
+    index,
+    locked,
+    make_redirect,
+    require_authenticated,
+)
 
 
 class InvenioOverride(object):
@@ -36,6 +43,7 @@ class InvenioOverride(object):
         app.add_url_rule("/", "index", index)
         self.init_config(app)
         app.register_error_handler(423, locked)
+        app.register_error_handler(Exception, default_error_handler)
         app.config["THEME_LOGO"] = app.config.get("OVERRIDE_LOGO")
         app.extensions["invenio-override"] = self
         routes = app.config.get("OVERRIDE_ROUTES")

--- a/invenio_override/templates/invenio_override/default_error.html
+++ b/invenio_override/templates/invenio_override/default_error.html
@@ -1,0 +1,29 @@
+{#
+  Copyright (C) 2024-2026 Graz University of Technology.
+
+  invenio-override is free software; you can redistribute it and/or
+  modify it under the terms of the MIT License; see LICENSE file for more
+  details.
+#}
+{% extends config.BASE_TEMPLATE %}
+{% block page_body %}
+  <div class="ui container rel-mt-4 rel-mb-4">
+    <div class="ui center aligned grid">
+      <div class="ten wide computer sixteen wide mobile twelve wide tablet column">
+        <h1>
+          <i class="bolt icon"></i>
+          {{ _("An unexpected error occurred") }}
+        </h1>
+        {% if config.OVERRIDE_SUPPORT_EMAIL %}
+          <p>
+            {{ _("Please contact <a href=\"mailto:{support_email}\">our support</a> to let us know about this error.").format(support_email=config.OVERRIDE_SUPPORT_EMAIL) }}
+          </p>
+        {% endif %}
+        <p>{{ _("Please include the following error ID in your message:") }}</p>
+        <p>
+          <strong>{{ error_id }}</strong>
+        </p>
+      </div>
+    </div>
+  </div>
+{% endblock page_body %}

--- a/invenio_override/views.py
+++ b/invenio_override/views.py
@@ -8,6 +8,8 @@
 
 """invenio module for sharedRDM theme."""
 
+import secrets
+import traceback
 from functools import wraps
 from typing import Dict, Optional
 
@@ -73,13 +75,29 @@ def index():
 
 
 def default_error_handler(e: Exception) -> tuple:
-    """
-    Handle unhandled errors.
+    """Handle unhandled errors.
+
+    Generates a unique error ID, logs the full traceback with it, and renders
+    the error page. The error ID makes it easy to correlate a user-reported
+    error with the corresponding log entry.
 
     :param e: Exception raised.
     :returns: Rendered error page with HTTP 500 status.
     """
-    return render_template(current_app.config["THEME_500_TEMPLATE"]), 500
+    error_id = secrets.token_hex(4)
+    tb = "".join(traceback.format_exception(e))
+    current_app.logger.error(
+        "(caught by invenio-override default_error_handler):\n"
+        "Error ID: #%s\nException class: %s\nException: %s\n%s",
+        error_id,
+        type(e),
+        e,
+        tb,
+    )
+    return (
+        render_template(current_app.config["THEME_500_TEMPLATE"], error_id=error_id),
+        500,
+    )
 
 
 @blueprint.app_template_filter("make_dict_like")


### PR DESCRIPTION
Adds a generic error page template and the OVERRIDE_SUPPORT_EMAIL config variable, replacing the equivalent from invenio-theme-tugraz with a reusable version for all instances.