### PR TITLE
fix: remove duplicate result count and flash message close button

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,6 +30,7 @@ recursive-include docs *.txt
 recursive-include docs Makefile
 recursive-include invenio_override *.html
 recursive-include invenio_override *.js
+recursive-include invenio_override *.jsx
 recursive-include invenio_override *.json
 recursive-include invenio_override *.png
 recursive-include invenio_override *.scss

--- a/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
+++ b/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
@@ -20,6 +20,7 @@ overrideStore.add(
   "InvenioAppRdm.DashboardCommunities.SearchApp.results",
   CommunitiesResults,
 );
+overrideStore.add("SearchApp.resultOptions", () => null);
 
 /* sticky notification setup for test instance */
 $(".ui.sticky.instance-banner").sticky({

--- a/invenio_override/assets/semantic-ui/less/invenio_override/dashboard.less
+++ b/invenio_override/assets/semantic-ui/less/invenio_override/dashboard.less
@@ -467,11 +467,13 @@
   justify-content: flex-end !important;
   margin-left: auto !important;
 }
-.uploads-search-app .row.computer.only .upload-new-wrap {
+.uploads-search-app .row.computer.only .upload-new-wrap,
+.uploads-search-app .upload-new-wrap {
   flex-direction: row-reverse;
   gap: 0.75rem;
 }
-.uploads-search-app .row.computer.only .upload-new-label-wrap {
+.uploads-search-app .row.computer.only .upload-new-label-wrap,
+.uploads-search-app .upload-new-label-wrap {
   text-align: right;
 }
 /* Col 2 (SharedOrMineFilter): natural width + white background with light-gray hover */

--- a/invenio_override/assets/semantic-ui/templates/InvenioRecordsLom.Search/SearchApp.results.jsx
+++ b/invenio_override/assets/semantic-ui/templates/InvenioRecordsLom.Search/SearchApp.results.jsx
@@ -1,0 +1,8 @@
+// Copyright (C) 2020-2026 Graz University of Technology.
+//
+// invenio-override is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+//
+// Override LOM search results to use the same UploadsResults component
+// as the RDM uploads dashboard (highlight-background row with count + sort).
+export { UploadsResults as default } from "../../js/invenio_override/UploadsResults";

--- a/invenio_override/templates/invenio_records_lom/uploads.html
+++ b/invenio_override/templates/invenio_records_lom/uploads.html
@@ -7,8 +7,9 @@
 
   Overrides: invenio_records_lom/uploads.html
   Changes:
-    - Replaced inline button with mobile action bar + JS-injected desktop
-      circle button, matching the RDM uploads page layout.
+    - Added mobile action bar with "New upload" button.
+    - Added desktop "New upload" circle button injected via JS into the
+      React search row after render.
 #}
 {%- extends config.LOM_BASE_TEMPLATE %}
 {%- set active_dashboard_menu_item = "OER" %}

--- a/invenio_override/templates/semantic-ui/invenio_theme/macros/messages.html
+++ b/invenio_override/templates/semantic-ui/invenio_theme/macros/messages.html
@@ -27,11 +27,6 @@
               <i class="info circle icon" aria-hidden="true"></i>
             {%- endif %}
             <span role="alert" id="flash-message">{{ msg }}</span>
-            <button class="ui icon button close-btn flash-close-btn"
-                    aria-label="{{ _('Close') }}"
-                    type="button">
-              <i class="times icon" aria-hidden="true"></i>
-            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Duplicate result count on all search pages sort.
Flash message close button: removed the close button from flash messages as it was not needed.