### PR TITLE
Feat help page

### DIFF
--- a/invenio_override/templates/invenio_override/help.html
+++ b/invenio_override/templates/invenio_override/help.html
@@ -1,0 +1,46 @@
+{#
+  Copyright (C) 2020-2026 Graz University of Technology.
+
+  invenio-override is free software; you can redistribute it and/or
+  modify it under the terms of the MIT License; see LICENSE file for more
+  details.
+#}
+{%- extends config.OVERRIDE_BASE_TEMPLATE %}
+{%- set title = _("Help & Support") %}
+{%- set page_description = _("Use the options below to get in touch with our team or learn how to get the most out of the search.") %}
+{%- block page_body %}
+  <div class="ui container rel-mt-3">
+    <div class="dashboard-nav-grid">
+      {%- if config.get('OVERRIDE_SHOW_CONTACT') or config.get('OVERRIDE_FRONTPAGE_RIGHT') %}
+        <a href="#" id="help-page-contact-trigger" class="dashboard-nav-box">
+          <div class="dashboard-nav-box-circle">
+            <i class="envelope outline icon"></i>
+          </div>
+          <div class="dashboard-nav-box-title">{{ _("Contact") }}</div>
+          <div class="dashboard-nav-box-desc">{{ _("Get in touch with our team.") }}</div>
+        </a>
+      {%- endif %}
+      <a href="/help/search" class="dashboard-nav-box">
+        <div class="dashboard-nav-box-circle">
+          <i class="search icon"></i>
+        </div>
+        <div class="dashboard-nav-box-title">{{ _("Search Guide") }}</div>
+        <div class="dashboard-nav-box-desc">{{ _("Learn how to search effectively.") }}</div>
+      </a>
+    </div>
+  </div>
+{%- endblock page_body %}
+{%- block javascript %}
+  {{ super() }}
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('help-page-contact-trigger');
+    if (btn) {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        $('#contact-modal').modal('show');
+      });
+    }
+  });
+  </script>
+{%- endblock javascript %}

--- a/invenio_override/templates/invenio_override/navbar.html
+++ b/invenio_override/templates/invenio_override/navbar.html
@@ -168,7 +168,7 @@
           <a class="header-topbar-link" href="{{ item.url }}">{{ admin_text }}</a>
         {%- endfor %}
         <div class="header-topbar-dropdown">
-          <a href="#" class="header-topbar-link" onclick="return false;">
+          <a href="/help" class="header-topbar-link">
             {{ _("Help") }} <span class="topbar-arrow"></span>
           </a>
           <div class="header-topbar-dropdown-menu">

--- a/invenio_override/views.py
+++ b/invenio_override/views.py
@@ -152,6 +152,12 @@ def locked(e) -> str:
     return render_template("invenio_override/423.html")
 
 
+@blueprint.route("/help")
+def help_page():
+    """Render the help page."""
+    return render_template("invenio_override/help.html")
+
+
 @blueprint.route("/communities")
 def communities_frontpage():
     """Render the communities overview page."""


### PR DESCRIPTION
 ### Description

Adds a dedicated /help page with two navigation circles, consistent with the Communities page layout:
 
  - Help & Support link in the navbar now navigates to /help instead of being a dead link
  - Contact circle opens the existing contact modal (only shown when OVERRIDE_SHOW_CONTACT or OVERRIDE_FRONTPAGE_RIGHT is set)
  - Search Guide circle links to /help/search

### Screenshot
<img width="517" height="320" alt="Screenshot 2026-05-28 at 09 47 46" src="https://github.com/user-attachments/assets/337c2c95-3493-473a-b942-ed19bd19db5e" />
