### PR TITLE
 Override marc21/lom uploads dashboard

### DIFF
--- a/invenio_override/assets/semantic-ui/less/invenio_override/dashboard.less
+++ b/invenio_override/assets/semantic-ui/less/invenio_override/dashboard.less
@@ -447,6 +447,9 @@
   .row.mobile.only:not(.tablet):has(.right.aligned.column),
 #invenio-search-lom-config.uploads-search-app .row.tablet.only:not(.mobile),
 #invenio-search-lom-config.uploads-search-app
+  .row.mobile.only:not(.tablet):has(.right.aligned.column),
+#invenio-search-marc21-config.uploads-search-app .row.tablet.only:not(.mobile),
+#invenio-search-marc21-config.uploads-search-app
   .row.mobile.only:not(.tablet):has(.right.aligned.column) {
   display: none !important;
 }
@@ -531,15 +534,21 @@
   display: none !important;
 }
 
-/* Col 3 (Sort): hidden in OER uploads — no SharedOrMineFilter so sort is one column earlier */
+/* Col 3 (Sort): hidden in OER and Publications uploads — no SharedOrMineFilter so sort is one column earlier */
 #invenio-search-lom-config.uploads-search-app
+  .row.computer.only
+  > .column:nth-child(3),
+#invenio-search-marc21-config.uploads-search-app
   .row.computer.only
   > .column:nth-child(3) {
   display: none !important;
 }
 
-/* Col 2 (SearchBar) in OER: match RDM search position (after missing 4-wide SharedOrMineFilter) */
+/* Col 2 (SearchBar) in OER and Publications: match RDM search position (after missing 4-wide SharedOrMineFilter) */
 #invenio-search-lom-config.uploads-search-app
+  .row.computer.only
+  > .column:nth-child(2),
+#invenio-search-marc21-config.uploads-search-app
   .row.computer.only
   > .column:nth-child(2) {
   flex: 0 0 auto !important;

--- a/invenio_override/templates/invenio_override/datamodels/lom_uploads.html
+++ b/invenio_override/templates/invenio_override/datamodels/lom_uploads.html
@@ -5,24 +5,14 @@
   modify it under the terms of the MIT License; see LICENSE file for more
   details.
 
-  Overrides: invenio_records_lom/uploads.html
-  Changes:
-    - Added mobile action bar with "New upload" button.
-    - Added desktop "New upload" circle button injected via JS into the
-      React search row after render.
+  Extends the lom (OER) uploads dashboard and fills the
+  `dashboard_actions` block with the "New upload" circle button
+  which is wired in via the LOM_UPLOADS_TEMPLATE config.
 #}
-{%- extends config.LOM_BASE_TEMPLATE %}
-{%- set active_dashboard_menu_item = "OER" %}
+{%- extends "invenio_records_lom/uploads.html" %}
 {%- set title = _("Educational Resources") %}
 {%- set page_description = _("Manage and publish your openly licensed educational materials.") %}
-{%- block javascript %}
-  {{ super() }}
-  {{ webpack['invenio-records-lom-user-dashboard.js'] }}
-{%- endblock javascript %}
-{%- block page_body %}
-  {%- block user_dashboard_header %}
-    {% include "invenio_app_rdm/users/header.html" %}
-  {%- endblock user_dashboard_header %}
+{%- block dashboard_actions %}
   <div class="dashboard-mobile-action-bar">
     <a href="/oer/uploads/new" class="upload-new-circle">
       <i class="upload icon"></i>
@@ -31,11 +21,6 @@
       <span class="upload-new-title">{{ _("New upload") }}</span>
       <span class="upload-new-desc">{{ _("Share your educational resources") }}</span>
     </div>
-  </div>
-  <div class="ui container rel-mt-2">
-    <div id="invenio-search-lom-config"
-         class="uploads-search-app"
-         data-invenio-search-config='{{ search_app_lom_user_uploads_config() | tojson }}'></div>
   </div>
   <div id="upload-new-circle-lom"
        class="upload-new-wrap"
@@ -77,4 +62,4 @@
     }, 100);
   })();
   </script>
-{%- endblock page_body %}
+{%- endblock dashboard_actions %}

--- a/invenio_override/templates/invenio_override/datamodels/marc21_uploads.html
+++ b/invenio_override/templates/invenio_override/datamodels/marc21_uploads.html
@@ -1,0 +1,65 @@
+{#
+  Copyright (C) 2020-2026 Graz University of Technology.
+
+  invenio-override is free software; you can redistribute it and/or
+  modify it under the terms of the MIT License; see LICENSE file for more
+  details.
+
+  Extends the marc21 publication uploads dashboard and fills the
+  `dashboard_actions` block with the "New upload" circle button
+  which is wired in via the MARC21_UPLOADS_TEMPLATE config.
+#}
+{%- extends "invenio_records_marc21/user_dashboard/uploads.html" %}
+{%- set title = _("Publication Uploads") %}
+{%- set page_description = _("Manage and publish your scientific publications.") %}
+{%- block dashboard_actions %}
+  <div class="dashboard-mobile-action-bar">
+    <a href="/publications/uploads/new" class="upload-new-circle">
+      <i class="upload icon"></i>
+    </a>
+    <div class="upload-new-label-wrap">
+      <span class="upload-new-title">{{ _("New upload") }}</span>
+      <span class="upload-new-desc">{{ _("Share your scientific publications") }}</span>
+    </div>
+  </div>
+  <div id="upload-new-circle-marc21"
+       class="upload-new-wrap"
+       style="display:none">
+    <a href="/publications/uploads/new" class="upload-new-circle">
+      <i class="upload icon"></i>
+    </a>
+    <div class="upload-new-label-wrap">
+      <span class="upload-new-title">{{ _("New upload") }}</span>
+      <span class="upload-new-desc">{{ _("Share your scientific publications") }}</span>
+    </div>
+  </div>
+  <script>
+  (function () {
+    function injectUploadCircle() {
+      var circle = document.getElementById('upload-new-circle-marc21');
+      if (!circle) return;
+      var filterRow = document.querySelector('#invenio-search-marc21-config .ui.grid > .row.computer.only');
+      if (!filterRow) return;
+      var firstCol = filterRow.querySelector('.column:first-child');
+      if (!firstCol) return;
+      firstCol.style.display = 'flex';
+      firstCol.style.alignItems = 'center';
+      firstCol.style.justifyContent = 'flex-start';
+      circle.style.display = 'inline-flex';
+      firstCol.appendChild(circle);
+    }
+
+    var attempts = 0;
+    var interval = setInterval(function () {
+      attempts++;
+      var row = document.querySelector('#invenio-search-marc21-config .ui.grid > .row.computer.only');
+      if (row) {
+        clearInterval(interval);
+        injectUploadCircle();
+      } else if (attempts > 40) {
+        clearInterval(interval);
+      }
+    }, 100);
+  })();
+  </script>
+{%- endblock dashboard_actions %}

--- a/invenio_override/templates/invenio_override/navbar.html
+++ b/invenio_override/templates/invenio_override/navbar.html
@@ -131,7 +131,7 @@
           <div class="header-topbar-dropdown-menu">
             <a href="/me/uploads" class="header-topbar-dropdown-item">{{ _("Research Results") }}</a>
             {% if config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH and current_user.is_authenticated %}
-              <a href="/publications/search" class="header-topbar-dropdown-item">{{ _("Publications") }}</a>
+              <a href="/publications/uploads" class="header-topbar-dropdown-item">{{ _("Publications") }}</a>
             {% endif %}
             {% if config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES %}
               <a href="/oer/uploads" class="header-topbar-dropdown-item">{{ _("Educational Resources") }}</a>


### PR DESCRIPTION
On the TUG instance the publication uploads dashboard should look and behave like the OER (LOM) uploads dashboard a "New upload" circle in the search row, a short page description under the title, and the same search-row layout 
Until now this was onlyachievable with a full template copy carried in the instance (only upload files left over)
  
 This PR uses the new MARC21_UPLOADS_TEMPLATE hook (added in the linked marc21 PR) to do it cleanly. It ships a template under invenio_override/datamodels/ that extends the marc21 default and fills the dashboard actions block with the upload circle, while setting the page title and description. The matching LESS makes the marc21 uploads search row mirror the OER layout. It also fixes the dashboard "Publications" navbar entry, which pointed at the public search page, to link to the user's uploads dashboard like the OER entry does.

 Nothing here lives in the instance anymore the override is a reusable part of invenio-override, grouped under datamodels/ to signal it's a data-model-specific override rather than core layout.
  
  Depends on the marc21 hook: .

  ---
  Two notes:
  - Link [#277 ](https://github.com/tu-graz-library/invenio-records-marc21/pull/277)
  - in config tugraz will be be: MARC21_UPLOADS_TEMPLATE = "invenio_override/datamodels/marc21_uploads.html"
