### PR TITLE
Make upload roles configurable

### DIFF
--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -41,6 +41,22 @@ OVERRIDE_SHOW_PUBLICATIONS_SEARCH = False
 OVERRIDE_SHOW_EDUCATIONAL_RESOURCES = False
 """Enable or disable the educational resources global search feature."""
 
+OVERRIDE_PUBLICATIONS_UPLOAD_ROLES = []
+"""Roles that may upload publications, on top of ``superuser-access``.
+
+Empty by default; set the data-model roles downstream, e.g.::
+
+    OVERRIDE_PUBLICATIONS_UPLOAD_ROLES = ["Marc21Manager", "Marc21Creator"]
+"""
+
+OVERRIDE_OER_UPLOAD_ROLES = []
+"""Roles that may upload educational resources, on top of ``superuser-access``.
+
+Empty by default; set the data-model roles downstream, e.g.::
+
+    OVERRIDE_OER_UPLOAD_ROLES = ["oer_certified_user", "oer_curator"]
+"""
+
 OVERRIDE_SHOW_RDM_SEARCH = False
 """Force UI to show only Research Results (RDM) in search/overview components."""
 

--- a/invenio_override/ext.py
+++ b/invenio_override/ext.py
@@ -57,20 +57,20 @@ class InvenioOverride(object):
 
         @app.context_processor
         def inject_visibility():
+            publication_roles = app.config["OVERRIDE_PUBLICATIONS_UPLOAD_ROLES"]
+            oer_roles = app.config["OVERRIDE_OER_UPLOAD_ROLES"]
             can_upload_publications = bool(
                 app.config.get("OVERRIDE_SHOW_PUBLICATIONS_SEARCH")
                 and (
-                    current_user.has_role("Marc21Manager")
-                    or current_user.has_role("Marc21Creator")
-                    or current_user.has_role("superuser-access")
+                    current_user.has_role("superuser-access")
+                    or any(current_user.has_role(role) for role in publication_roles)
                 )
             )
             can_upload_oer = bool(
                 app.config.get("OVERRIDE_SHOW_EDUCATIONAL_RESOURCES")
                 and (
-                    current_user.has_role("oer_certified_user")
-                    or current_user.has_role("oer_curator")
-                    or current_user.has_role("superuser-access")
+                    current_user.has_role("superuser-access")
+                    or any(current_user.has_role(role) for role in oer_roles)
                 )
             )
             return {


### PR DESCRIPTION
 The theme hardcoded the marc21 and lom role names in upload visibility checks. As a generic theme it shouldn't know about specific data-model roles, so this moves them to config.
  
Config changes: https://github.com/tu-graz-library/invenio-config-tugraz/commit/f1b11019f1efe3881ff33f8e930a173efde9a9a0