### PR TITLE
Fix community banner and refactoring 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           python-version: '3.14'
       - name: Install djlint
-        run: pip install djlint
+        run: pip install "djlint~=1.36.4"
       - name: Check HTML templates
         run: djlint --check invenio_override/templates/

--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -41,22 +41,6 @@ OVERRIDE_SHOW_PUBLICATIONS_SEARCH = False
 OVERRIDE_SHOW_EDUCATIONAL_RESOURCES = False
 """Enable or disable the educational resources global search feature."""
 
-OVERRIDE_PUBLICATIONS_UPLOAD_ROLES = []
-"""Roles that may upload publications, on top of ``superuser-access``.
-
-Empty by default; set the data-model roles downstream, e.g.::
-
-    OVERRIDE_PUBLICATIONS_UPLOAD_ROLES = ["Marc21Manager", "Marc21Creator"]
-"""
-
-OVERRIDE_OER_UPLOAD_ROLES = []
-"""Roles that may upload educational resources, on top of ``superuser-access``.
-
-Empty by default; set the data-model roles downstream, e.g.::
-
-    OVERRIDE_OER_UPLOAD_ROLES = ["oer_certified_user", "oer_curator"]
-"""
-
 OVERRIDE_SHOW_RDM_SEARCH = False
 """Force UI to show only Research Results (RDM) in search/overview components."""
 

--- a/invenio_override/ext.py
+++ b/invenio_override/ext.py
@@ -8,6 +8,8 @@
 
 """invenio module for sharedRDM theme."""
 
+from types import SimpleNamespace
+
 from flask import g, request
 from flask_login import login_required
 from flask_menu import current_menu
@@ -21,12 +23,16 @@ except (ImportError, AttributeError):
 try:
     from invenio_records_marc21.proxies import current_records_marc21
 except ImportError:
-    current_records_marc21 = None
+    current_records_marc21 = SimpleNamespace(
+        records_service=SimpleNamespace(check_permission=lambda *args, **kwargs: False)
+    )
 
 try:
     from invenio_records_lom.proxies import current_records_lom
 except ImportError:
-    current_records_lom = None
+    current_records_lom = SimpleNamespace(
+        records_service=SimpleNamespace(check_permission=lambda *args, **kwargs: False)
+    )
 
 from . import config
 from .views import (
@@ -71,14 +77,12 @@ class InvenioOverride(object):
             # decides who may upload.
             can_upload_publications = bool(
                 app.config.get("OVERRIDE_SHOW_PUBLICATIONS_SEARCH")
-                and current_records_marc21
                 and current_records_marc21.records_service.check_permission(
                     g.identity, "create"
                 )
             )
             can_upload_oer = bool(
                 app.config.get("OVERRIDE_SHOW_EDUCATIONAL_RESOURCES")
-                and current_records_lom
                 and current_records_lom.records_service.check_permission(
                     g.identity, "handle_oer"
                 )

--- a/invenio_override/ext.py
+++ b/invenio_override/ext.py
@@ -8,8 +8,8 @@
 
 """invenio module for sharedRDM theme."""
 
-from flask import request
-from flask_login import current_user, login_required
+from flask import g, request
+from flask_login import login_required
 from flask_menu import current_menu
 from invenio_i18n import lazy_gettext as _
 
@@ -17,6 +17,16 @@ try:
     from invenio_records_marc21.ui.theme import current_identity_can_view
 except (ImportError, AttributeError):
     current_identity_can_view = lambda: False
+
+try:
+    from invenio_records_marc21.proxies import current_records_marc21
+except ImportError:
+    current_records_marc21 = None
+
+try:
+    from invenio_records_lom.proxies import current_records_lom
+except ImportError:
+    current_records_lom = None
 
 from . import config
 from .views import (
@@ -57,20 +67,20 @@ class InvenioOverride(object):
 
         @app.context_processor
         def inject_visibility():
-            publication_roles = app.config["OVERRIDE_PUBLICATIONS_UPLOAD_ROLES"]
-            oer_roles = app.config["OVERRIDE_OER_UPLOAD_ROLES"]
+            # OVERRIDE_SHOW_* gates the feature; the data-model permission
+            # decides who may upload.
             can_upload_publications = bool(
                 app.config.get("OVERRIDE_SHOW_PUBLICATIONS_SEARCH")
-                and (
-                    current_user.has_role("superuser-access")
-                    or any(current_user.has_role(role) for role in publication_roles)
+                and current_records_marc21
+                and current_records_marc21.records_service.check_permission(
+                    g.identity, "create"
                 )
             )
             can_upload_oer = bool(
                 app.config.get("OVERRIDE_SHOW_EDUCATIONAL_RESOURCES")
-                and (
-                    current_user.has_role("superuser-access")
-                    or any(current_user.has_role(role) for role in oer_roles)
+                and current_records_lom
+                and current_records_lom.records_service.check_permission(
+                    g.identity, "handle_oer"
                 )
             )
             return {
@@ -84,6 +94,10 @@ class InvenioOverride(object):
             descriptions = {
                 "invenio_communities.communities_search": _(
                     "Browse and discover all communities"
+                ),
+                "invenio_app_rdm.help_search": _(
+                    "This guide explains how to write advanced search queries "
+                    "using easy to understand examples."
                 ),
                 "invenio_records_marc21.deposit_create": _("Deposit a publication"),
                 "invenio_records_marc21.deposit_edit": _("Deposit a publication"),

--- a/invenio_override/templates/invenio_override/header.html
+++ b/invenio_override/templates/invenio_override/header.html
@@ -41,10 +41,11 @@
 #}
   {%- block page_inner_banner %}
     {%- set _path = request.path %}
-    {%- if (title or _path == '/publications/search') and not (_path.startswith('/records/') and not _path.startswith('/records/search')) %}
+    {%- set _is_community_detail = _path.startswith('/communities/') and _path not in ['/communities/search', '/communities/new'] %}
+    {%- if (title or _is_community_detail or _path == '/publications/search') and not (_path.startswith('/records/') and not _path.startswith('/records/search')) %}
       <div class="page-inner-banner">
         <div class="ui container">
-          <h1 class="page-inner-banner-title">{{ title or _("Publications") }}</h1>
+          <h1 class="page-inner-banner-title">{{ _("Community") if _is_community_detail else (title or _("Publications")) }}</h1>
           {%- if page_description %}
             <p class="page-inner-banner-description">{{ page_description }}</p>
           {%- elif _path == '/me/uploads' %}
@@ -61,6 +62,10 @@
             </p>
           {%- elif _path == '/communities/new' %}
             <p class="page-inner-banner-description">{{ _("Create a community to organize and share your research outputs.") }}</p>
+          {%- elif _is_community_detail %}
+            <p class="page-inner-banner-description">
+              {{ _("Browse and manage this community's records, members and requests.") }}
+            </p>
           {%- elif _path.startswith('/account/settings') %}
             <p class="page-inner-banner-description">{{ _("Manage your profile, security and connected applications.") }}</p>
           {%- elif _path == '/publications/search' %}


### PR DESCRIPTION
 Two improvements:

### Cleaner page banners
On community pages (records, requests, members, settings, curation policy,on at the end. It now shows one clean title and a short description, like the rest of the site. The search guide page also gets a proper description in its banner.
  
### Upload links follow the data model's permissions
The "Upload publication / educational resource" links were shown based on a role list kept here in the theme, which duplicated the roles already defined in the marc21 and lom packages. Now the theme simply asks each package whether the user is allowed to upload. The roles live in one place; adding a role there is picked up automatically, with nothing to keep in sync.
  
Companion PR: tu-graz-library/invenio-config-tugraz#159