### PR TITLE
Prevent page load flash app

### DIFF
--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -146,6 +146,12 @@ Example::
 OVERRIDE_BASE_TEMPLATE = "invenio_override/base.html"
 """Default base template"""
 
+BASE_TEMPLATE = "invenio_override/page.html"
+"""App-wide base template — adds the FOUC guard on top of invenio-app-rdm's page base."""
+
+THEME_BASE_TEMPLATE = "invenio_override/page.html"
+"""Keep THEME_BASE_TEMPLATE in sync with BASE_TEMPLATE."""
+
 OVERRIDE_ACCOUNT_BASE = "invenio_override/accounts/accounts_base.html"
 """Default account base template"""
 

--- a/invenio_override/templates/invenio_override/base.html
+++ b/invenio_override/templates/invenio_override/base.html
@@ -52,9 +52,7 @@
       {%- block css %}
         {{ webpack['theme.css'] }}
         {{ webpack['invenio-override-theme.css'] }}
-        <style>body{opacity:0;transition:opacity .15s ease}</style>
-        <noscript><style>body{opacity:1}</style></noscript>
-        <script>document.addEventListener('DOMContentLoaded',function(){document.body.style.opacity='1'});</script>
+        {% include "invenio_override/fouc_guard.html" %}
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
         <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/invenio_override/templates/invenio_override/fouc_guard.html
+++ b/invenio_override/templates/invenio_override/fouc_guard.html
@@ -1,0 +1,31 @@
+{#
+  Copyright (C) 2026 Graz University of Technology.
+
+  invenio-override is free software; you can redistribute it and/or
+  modify it under the terms of the MIT License; see LICENSE file for more
+  details.
+
+  App-wide FOUC guard. Hides the body until the client side widgets
+  have initialised, so the server rendered placeholders dont flash
+  before JS fills them in.
+#}
+<style>
+  body { opacity: 0; }
+  body.ready { opacity: 1; transition: opacity 0.15s ease; }
+</style>
+<noscript>
+  <style>body { opacity: 1; }</style>
+</noscript>
+<script>
+  (function () {
+    function reveal() {
+      if (document.body) document.body.classList.add("ready");
+    }
+    if (document.readyState === "complete") {
+      reveal();
+    } else {
+      window.addEventListener("load", reveal);
+    }
+    setTimeout(reveal, 1500);
+  })();
+</script>

--- a/invenio_override/templates/invenio_override/page.html
+++ b/invenio_override/templates/invenio_override/page.html
@@ -1,0 +1,15 @@
+{#
+  Copyright (C) 2026 Graz University of Technology.
+
+  invenio-override is free software; you can redistribute it and/or
+  modify it under the terms of the MIT License; see LICENSE file for more
+  details.
+
+  Extends invenio-app-rdm's page base and adds the FOUC guard into
+  every page that extends config.BASE_TEMPLATE hides until its client widgets mount.
+#}
+{%- extends "invenio_app_rdm/page.html" %}
+{%- block css %}
+  {{ super() }}
+  {% include "invenio_override/fouc_guard.html" %}
+{%- endblock css %}


### PR DESCRIPTION
 On every page load there was a short flash so the server-rendered HTML appeared first, then the page settled once the client-side widgets initialised so for a moment u see an unfinished state before everything. 
 
We already had a guard for this, but it only lived in our own base template, which is used for the frontpage. Every other page  extends invenio-app-rdm's page base through config.BASE_TEMPLATE and that had no guard at all thats why the flash kept showing everywhere except the frontpage.
 
I solved it by placing in one place I pulled the guard into a small shared partial and added a thin base template that extends invenio-app-rdm's page and drops the guard into the css block and then I pointed BASE_TEMPLATE at that base, so every page now hides the body until the widgets have loaded. 


## Current state including the one in prod 

https://github.com/user-attachments/assets/5d033a55-51b6-409c-8250-cebbf668e36d

## After


https://github.com/user-attachments/assets/e2ba6fd7-c0c8-47b2-ace3-35e89bfefd15

