### PR TITLE
New communities frontpage

### DIFF
--- a/invenio_override/assets/semantic-ui/js/invenio_override/communities/index.js
+++ b/invenio_override/assets/semantic-ui/js/invenio_override/communities/index.js
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (newContainer) {
     ReactDOM.render(
       <CommunityCards
-        fetchUrl="/api/communities?sort=newest&size=10"
+        fetchUrl="/api/communities?sort=newest&size=5"
         defaultLogo={DEFAULT_LOGO}
         emptyMessage="No communities yet."
       />,

--- a/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
+++ b/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
@@ -235,3 +235,35 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+
+/* Frontpage tabbed section: Recent uploads <-> New communities.*/
+function initFrontpageTabs() {
+  const root = document.querySelector(".frontpage-tabbed");
+  if (!root) {
+    return;
+  }
+
+  const activate = (name) => {
+    root.querySelectorAll(".frontpage-tab").forEach((tab) => {
+      tab.classList.toggle("active", tab.dataset.tab === name);
+    });
+    root.querySelectorAll(".frontpage-tab-panel").forEach((panel) => {
+      panel.hidden = panel.dataset.panel !== name;
+    });
+    root.querySelectorAll(".more[data-more]").forEach((link) => {
+      link.hidden = link.dataset.more !== name;
+    });
+  };
+
+  root.querySelectorAll(".frontpage-tab").forEach((tab) => {
+    tab.addEventListener("click", () => activate(tab.dataset.tab));
+    tab.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        activate(tab.dataset.tab);
+      }
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initFrontpageTabs);

--- a/invenio_override/assets/semantic-ui/less/invenio_override/communities.less
+++ b/invenio_override/assets/semantic-ui/less/invenio_override/communities.less
@@ -137,11 +137,33 @@
 }
 
 /* ======================================
+   Community list/search result item
+====================================== */
+.community-item .community-image,
+.community-item .ui.image.community-image {
+  width: 80px !important;
+  height: 80px !important;
+  min-width: 80px !important;
+  max-width: 80px !important;
+  overflow: hidden !important;
+  object-fit: contain !important;
+  flex-shrink: 0;
+}
+
+.community-item .community-image img {
+  width: 100% !important;
+  height: 100% !important;
+  max-width: 80px !important;
+  max-height: 80px !important;
+  object-fit: contain !important;
+}
+
+/* ======================================
    Override community cards — clean grid
 ====================================== */
 .override-community-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: @contentGridGap;
   margin-bottom: @contentGridMarginV;
 }
@@ -169,17 +191,18 @@
 
 .override-community-card-logo {
   width: 100%;
-  height: 120px;
+  aspect-ratio: 1 / 1;
   overflow: hidden;
-  background: #f5f5f6;
+  background: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0.5rem;
 
   img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
   }
 }
 

--- a/invenio_override/assets/semantic-ui/less/invenio_override/frontpage.less
+++ b/invenio_override/assets/semantic-ui/less/invenio_override/frontpage.less
@@ -408,6 +408,11 @@ h2 {
 
   .more {
     display: inline-block;
+
+    &[hidden] {
+      display: none;
+    }
+
     padding: 0.5em 1.3em;
     border: 1px solid #000000;
     border-radius: @radiusPill;
@@ -454,6 +459,48 @@ h2 {
   flex: 1;
   height: 1px;
   background: rgba(0, 0, 0, 0.12);
+}
+
+/* ======================================
+   Tabbed section header 
+====================================== */
+.frontpage-tabs {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+
+  .frontpage-tab {
+    margin: 0 !important;
+    white-space: nowrap;
+    font-size: clamp(1.4rem, 3vw, 1.9rem);
+    font-weight: 800;
+    line-height: 1.15;
+    cursor: pointer;
+    color: rgba(0, 0, 0, 0.55);
+    border-bottom: 3px solid transparent;
+    padding-bottom: 0.2rem;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+
+    &::after {
+      display: none !important;
+    }
+
+    &:hover {
+      color: rgba(0, 0, 0, 0.78);
+    }
+
+    &.active,
+    &.active:hover {
+      color: @primaryText;
+      border-bottom-color: @overridePrimary;
+    }
+  }
+}
+
+.frontpage-tab-panel[hidden] {
+  display: none;
 }
 
 .section-more-link {

--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -83,6 +83,9 @@ OVERRIDE_FRONTPAGE_RIGHT = True
 OVERRIDE_FRONTPAGE_SUBTITLE = ""
 """Subtitle displayed below the frontpage title in the hero section."""
 
+OVERRIDE_FRONTPAGE_SHOW_NEW_COMMUNITIES = True
+"""Show the "New communities" tab next to "Recent uploads" on the frontpage."""
+
 OVERRIDE_REASONS_PARTNER = "CERN"
 """Trusted partner name shown in the 'Why use X?' reasons strip on the frontpage."""
 

--- a/invenio_override/templates/invenio_override/frontpage.html
+++ b/invenio_override/templates/invenio_override/frontpage.html
@@ -8,6 +8,7 @@
 {%- set main_column_width = "ten" if config.OVERRIDE_FRONTPAGE_RIGHT else "sixteen" %}
 {%- block javascript %}
   {{ webpack['invenio-override-js.js'] }}
+  {{ webpack['invenio-override-communities.js'] }}
 {%- endblock javascript %}
 {%- from "invenio_override/macros/authors.html" import creators -%}
 {%- from "invenio_app_rdm/macros/records_list.html" import records_list %}

--- a/invenio_override/templates/invenio_override/recent_uploads.html
+++ b/invenio_override/templates/invenio_override/recent_uploads.html
@@ -5,65 +5,91 @@
   modify it under the terms of the MIT License; see LICENSE file for more
   details.
 #}
-<section class="random-records-frontpage"
-         aria-label="{{ _('Recent uploads') }}">
+<section class="random-records-frontpage frontpage-tabbed"
+         aria-label="{{ _('Recent uploads and new communities') }}">
   <div class="section-header">
-    <h2>{{ _("Recent uploads") }}</h2>
-    <div class="section-header-line"></div>
-    <a href="{{ url_for('invenio_search_ui.search') }}" class="more">{{ _("All uploads") }} →</a>
-  </div>
-  {% if not records %}
-    <div class="ui centered grid">
-      <p style="font-size: medium;">
-        {% if config.OVERRIDE_SHOW_RDM_SEARCH or (not config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH or not config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES) %}
-          {{ _("Explore Research Results available in the repository.") }}
-        {% else %}
-          {{ _("There are no public records to show.") }}
-        {% endif %}
-      </p>
+    <div class="frontpage-tabs" role="tablist">
+      <h2 class="frontpage-tab active"
+          role="tab"
+          tabindex="0"
+          data-tab="uploads">{{ _("Recent uploads") }}</h2>
+      {%- if config.OVERRIDE_FRONTPAGE_SHOW_NEW_COMMUNITIES %}
+        <h2 class="frontpage-tab" role="tab" tabindex="0" data-tab="communities">{{ _("New communities") }}</h2>
+      {%- endif %}
     </div>
-  {% endif %}
-  {%- for r in records %}
-    {%- set creation_date = r.created | from_isodatetime -%}
-    {%- set record_url = r.original.view %}
-    <article class="record-card">
-      <div class="badges">
-        <span class="ui small horizontal label primary theme-primary">{{ r.created_date_l10n_long }}</span>
-        {% if r.metadata.types | length > 0 %}
-          <span class="ui small horizontal label neutral">{{ r.metadata.types[0] }}</span>
-        {% endif %}
-        <span class="ui small horizontal label access-status {{ r.access_status.id }}">
-          <i class="icon {{ r.access_status.icon }}"></i>
-          {{ r.access_status.title_l10n }}
-        </span>
-        <span class="ui small horizontal label schema">{{ r.original.schema_l10n }}</span>
-      </div>
-      <h4>
-        <a href="{{ record_url }}">{{ r.metadata.titles[0] }}</a>
-      </h4>
-      <p class="record-card-creators">
-        {%- for creator in r.metadata.creators %}
-          <span>{{ creator }}
-            {% if not loop.last %};{% endif %}
-          </span>
-        {%- endfor %}
-      </p>
-      {% if r.metadata.descriptions %}
-        <p class="record-card-description hidden-xs">
-          <a href="{{ record_url }}" style="color: inherit; text-decoration: none">
-            {{ r.metadata.descriptions | join(" ") | striptags | safe | truncate(300) }}
-          </a>
-        </p>
-      {% endif %}
-      <div class="record-card-meta">
-        <small>{{ _("Uploaded on") }} {{ r.created_date_l10n_long }}</small>
-        <div class="record-card-stats">
-          {% if r.stats is defined %}
-            <span><i class="eye icon"></i> {{ r.stats.all_versions.unique_views or 0 }}</span>
-            <span><i class="download icon"></i> {{ r.stats.all_versions.unique_downloads or 0 }}</span>
+    <div class="section-header-line"></div>
+    <a href="{{ url_for('invenio_search_ui.search') }}"
+       class="more"
+       data-more="uploads">{{ _("All uploads") }} →</a>
+    {%- if config.OVERRIDE_FRONTPAGE_SHOW_NEW_COMMUNITIES %}
+      <a href="{{ url_for('invenio_communities.communities_search') }}"
+         class="more"
+         data-more="communities"
+         hidden>{{ _("All communities") }} →</a>
+    {%- endif %}
+  </div>
+  {# Panel: Recent uploads #}
+  <div class="frontpage-tab-panel" data-panel="uploads">
+    {% if not records %}
+      <div class="ui centered grid">
+        <p style="font-size: medium;">
+          {% if config.OVERRIDE_SHOW_RDM_SEARCH or (not config.OVERRIDE_SHOW_PUBLICATIONS_SEARCH or not config.OVERRIDE_SHOW_EDUCATIONAL_RESOURCES) %}
+            {{ _("Explore Research Results available in the repository.") }}
+          {% else %}
+            {{ _("There are no public records to show.") }}
           {% endif %}
-        </div>
+        </p>
       </div>
-    </article>
-  {%- endfor %}
+    {% endif %}
+    {%- for r in records %}
+      {%- set creation_date = r.created | from_isodatetime -%}
+      {%- set record_url = r.original.view %}
+      <article class="record-card">
+        <div class="badges">
+          <span class="ui small horizontal label primary theme-primary">{{ r.created_date_l10n_long }}</span>
+          {% if r.metadata.types | length > 0 %}
+            <span class="ui small horizontal label neutral">{{ r.metadata.types[0] }}</span>
+          {% endif %}
+          <span class="ui small horizontal label access-status {{ r.access_status.id }}">
+            <i class="icon {{ r.access_status.icon }}"></i>
+            {{ r.access_status.title_l10n }}
+          </span>
+          <span class="ui small horizontal label schema">{{ r.original.schema_l10n }}</span>
+        </div>
+        <h4>
+          <a href="{{ record_url }}">{{ r.metadata.titles[0] }}</a>
+        </h4>
+        <p class="record-card-creators">
+          {%- for creator in r.metadata.creators %}
+            <span>{{ creator }}
+              {% if not loop.last %};{% endif %}
+            </span>
+          {%- endfor %}
+        </p>
+        {% if r.metadata.descriptions %}
+          <p class="record-card-description hidden-xs">
+            <a href="{{ record_url }}" style="color: inherit; text-decoration: none">
+              {{ r.metadata.descriptions | join(" ") | striptags | safe | truncate(300) }}
+            </a>
+          </p>
+        {% endif %}
+        <div class="record-card-meta">
+          <small>{{ _("Uploaded on") }} {{ r.created_date_l10n_long }}</small>
+          <div class="record-card-stats">
+            {% if r.stats is defined %}
+              <span><i class="eye icon"></i> {{ r.stats.all_versions.unique_views or 0 }}</span>
+              <span><i class="download icon"></i> {{ r.stats.all_versions.unique_downloads or 0 }}</span>
+            {% endif %}
+          </div>
+        </div>
+      </article>
+    {%- endfor %}
+  </div>
+  {%- if config.OVERRIDE_FRONTPAGE_SHOW_NEW_COMMUNITIES %}
+    {# Panel: New communities — core cards, fed by /api/communities?sort=newest.
+       Tab switching + styling live in theme.js and frontpage.less. #}
+    <div class="frontpage-tab-panel" data-panel="communities" hidden>
+      <div id="new-communities"></div>
+    </div>
+  {%- endif %}
 </section>

--- a/invenio_override/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_override/translations/de/LC_MESSAGES/messages.po
@@ -825,6 +825,14 @@ msgstr "Verwalten Sie Ihr Profil, Ihre Einstellungen und Kontooptionen."
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
+#: invenio_override/templates/invenio_override/recent_uploads.html:9
+msgid "Recent uploads and new communities"
+msgstr "Neueste Uploads und neue Gruppen"
+
+#: invenio_override/templates/invenio_override/recent_uploads.html:31
+msgid "All communities"
+msgstr "Alle Gruppen"
+
 #~ msgid "Search"
 #~ msgstr "Suchen"
 

--- a/invenio_override/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_override/translations/en/LC_MESSAGES/messages.po
@@ -753,6 +753,14 @@ msgstr ""
 msgid "Account settings"
 msgstr ""
 
+#: invenio_override/templates/invenio_override/recent_uploads.html:9
+msgid "Recent uploads and new communities"
+msgstr ""
+
+#: invenio_override/templates/invenio_override/recent_uploads.html:31
+msgid "All communities"
+msgstr ""
+
 #~ msgid "Search"
 #~ msgstr ""
 

--- a/invenio_override/translations/messages.pot
+++ b/invenio_override/translations/messages.pot
@@ -751,3 +751,11 @@ msgstr ""
 msgid "Account settings"
 msgstr ""
 
+#: invenio_override/templates/invenio_override/recent_uploads.html:9
+msgid "Recent uploads and new communities"
+msgstr ""
+
+#: invenio_override/templates/invenio_override/recent_uploads.html:31
+msgid "All communities"
+msgstr ""
+


### PR DESCRIPTION
Surfaces newly created communities on the landing page so users discover them as easily as recent uploads. Instead of a separate section that pushes the page down, "New communities" is a tab next to "Recent uploads" at the same level click to switch between the two.

  What changed

  - Tabbed section : "Recent uploads" / "New communities" tabs sharing the existing section header. The All uploads : button is unchanged; an identical All communities: button shows only when the communities tab is active.
  - Cards: reuse the existing CommunityCards component, fed by the core endpoint /api/communities?sort=newest. Title, description, logo and link come straight from each community's real metadata nothing hardcoded.
  - Card layout : 5 larger cards with a fixed square logo box (aspect-ratio: 1/1, object-fit: contain, overflow: hidden) so logos are shown in full and can never crop or overflow into the text/link (the known list-view overflow issue is avoided by construction).
  - Tab behaviour/styling: switching logic in theme.js, styling in frontpage.less 
  - Config flag: gated behind OVERRIDE_FRONTPAGE_SHOW_NEW_COMMUNITIES (default True) so instances can opt out. Default lives in invenio-override; no config-tugraz change needed.
  - i18n: German added for the new strings (All communities, the aria-label), consistent with the catalog's existing wording.



<img width="1866" height="823" alt="Screenshot 2026-06-19 at 10 21 50" src="https://github.com/user-attachments/assets/27a638e9-27c8-487e-8f0a-84002cee6812" />
<img width="1716" height="549" alt="Screenshot 2026-06-19 at 10 21 13" src="https://github.com/user-attachments/assets/8a2de6a7-b9f2-471d-9eba-fc4ec9a0d0e0" />
