### PR TITLE
Theme search header fixes

### DIFF
--- a/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
+++ b/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
@@ -16,11 +16,21 @@ overrideStore.add(
   UploadsResults,
 );
 overrideStore.add("SearchApp.results", UploadsResults);
+overrideStore.add("InvenioAppRdm.Search.SearchApp.results", UploadsResults);
+overrideStore.add(
+  "GlobalSearchRecords.Search.SearchApp.results",
+  UploadsResults,
+);
 overrideStore.add(
   "InvenioAppRdm.DashboardCommunities.SearchApp.results",
   CommunitiesResults,
 );
 overrideStore.add("SearchApp.resultOptions", () => null);
+overrideStore.add("InvenioAppRdm.Search.SearchApp.resultOptions", () => null);
+overrideStore.add(
+  "GlobalSearchRecords.Search.SearchApp.resultOptions",
+  () => null,
+);
 
 /* sticky notification setup for test instance */
 $(".ui.sticky.instance-banner").sticky({

--- a/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
+++ b/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
@@ -87,7 +87,7 @@
 ====================================== */
 
 /* Home stroke SVG styling */
-.home-stroke polyline {
+.home-stroke {
   stroke: @overridePrimary;
   stroke-linecap: square;
   stroke-width: 4;

--- a/invenio_override/templates/invenio_override/navbar.html
+++ b/invenio_override/templates/invenio_override/navbar.html
@@ -86,11 +86,11 @@
           {% endif %}
           {% if config.get('OVERRIDE_HEADER_LOGO_SVG') %}
             <img id="int-header-logo-img"
-                 height="48"
+                 height="{{ config.get('OVERRIDE_HEADER_LOGO_HEIGHT', 48) }}"
                  src="{{ url_for('static', filename=config.OVERRIDE_HEADER_LOGO_SVG) }}">
           {% elif config.get('OVERRIDE_LOGO') %}
             <img id="int-header-logo-img"
-                 height="64"
+                 height="{{ config.get('OVERRIDE_HEADER_LOGO_HEIGHT', 64) }}"
                  src="{{ url_for('static', filename=config.OVERRIDE_LOGO) }}">
           {% endif %}
         </a>
@@ -112,7 +112,7 @@
                height="36.997"
                width="35.969"
                viewBox="0 0 35.969 36.997451">
-            <polyline class="home-stroke" style="stroke:#e4154b;stroke-linecap:square;stroke-width:4;fill:none" points="282.72 437.28 282.72 414.77 297.71 406.69 312.69 414.77 312.69 437.28" transform="translate(-279.72 -403.28)">
+            <polyline class="home-stroke" points="282.72 437.28 282.72 414.77 297.71 406.69 312.69 414.77 312.69 437.28" transform="translate(-279.72 -403.28)">
             </polyline>
           </svg>
         </span>


### PR DESCRIPTION
<img width="1419" height="327" alt="Screenshot 2026-06-19 at 12 28 05" src="https://github.com/user-attachments/assets/2960bd86-12ab-467a-837d-02920a28a889" />

Research Result missing new container for results: 
<img width="1458" height="323" alt="Screenshot 2026-06-19 at 12 27 59" src="https://github.com/user-attachments/assets/3d7dc117-6ec8-4da7-8b3a-eef1ae26881b" />

Home icon was intially hardcoded, while testing removed that. Also Logos, size configured, need that
