### PR TITLE
Configurable contact form bundle

### DIFF
--- a/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
+++ b/invenio_override/assets/semantic-ui/js/invenio_override/theme.js
@@ -114,31 +114,6 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 
-/* load Zammad script on document ready
-$(function () {
-  importZammadScript();
-});
-*/
-
-/* function to import Zammad script for feedback form
-function importZammadScript() {
-  let scriptNode = document.createElement("hidden");
-  scriptNode.id = "zammad_form_script";
-  scriptNode.src = "URL";
-  document.head.appendChild(scriptNode);
-
-  $.getScript("URL", () => {
-    $("#feedback-form").ZammadForm({
-      messageTitle: "Contact us",
-      showTitle: true,
-      messageSubmit: "Submit",
-      messageThankYou: "Thank you for your message, (#%s). We will get back to you as quickly as possible!",
-      modal: true,
-    });
-  });
-}
-*/
-
 /* function to toggle visibility of an element by ID
 export function toggleVisibility(id) {
   const element = document.getElementById(id);

--- a/invenio_override/config.py
+++ b/invenio_override/config.py
@@ -179,6 +179,9 @@ OVERRIDE_EDUGAIN_ICON = "icons/eduGAIN-FavIcon-transparent.png"
 OVERRIDE_CONTACT_FORM = False
 """Enable/Disable Contact form."""
 
+OVERRIDE_CONTACT_FORM_BUNDLE = None
+"""Webpack bundle that activates the contact form """
+
 # ============================================================================
 # Production and Shibboleth Configuration
 # ============================================================================

--- a/invenio_override/templates/invenio_override/contact_us.html
+++ b/invenio_override/templates/invenio_override/contact_us.html
@@ -8,21 +8,22 @@
 <div class="ui segment">
   <h4>{{ _("Need help?") }}</h4>
   {%- if config.OVERRIDE_CONTACT_FORM %}
-    <div style="padding-bottom: 10px;">
-      <a id="feedback-form" class="fluid ui button">{{ _("Contact us") }}</a>
-    </div>
-  {%- endif %}
-  {%- if config.OVERRIDE_SHOW_RIGHT_CONTACT_EMAIL %}
-    <div style="padding-bottom: 10px;">
-      <a href="mailto:{{ config.OVERRIDE_RIGHT_SECTION_CONTACT_EMAIL }}"
-         class="fluid ui button">{{ _("Contact our Help Service") }}</a>
-    </div>
-  {%- endif %}
-  <p>{{ _("We can help with:") }}</p>
-  <ul>
-    <li>{{ _("Upload your research results, software, preprints, etc.") }}</li>
-    <li>{{ _("Increase upload limit beyond our default policy of 10GB.") }}</li>
-    <li>{{ _("Establish contact with data stewards.") }}</li>
-    <li>{{ _("Find individual solutions.") }}</li>
-  </ul>
-</div>
+    {%- if config.OVERRIDE_CONTACT_FORM_BUNDLE %}{{ webpack[config.OVERRIDE_CONTACT_FORM_BUNDLE] }}{%- endif %}
+      <div style="padding-bottom: 10px;">
+        <a id="feedback-form" class="fluid ui button">{{ _("Contact us") }}</a>
+      </div>
+    {%- endif %}
+    {%- if config.OVERRIDE_SHOW_RIGHT_CONTACT_EMAIL %}
+      <div style="padding-bottom: 10px;">
+        <a href="mailto:{{ config.OVERRIDE_RIGHT_SECTION_CONTACT_EMAIL }}"
+           class="fluid ui button">{{ _("Contact our Help Service") }}</a>
+      </div>
+    {%- endif %}
+    <p>{{ _("We can help with:") }}</p>
+    <ul>
+      <li>{{ _("Upload your research results, software, preprints, etc.") }}</li>
+      <li>{{ _("Increase upload limit beyond our default policy of 10GB.") }}</li>
+      <li>{{ _("Establish contact with data stewards.") }}</li>
+      <li>{{ _("Find individual solutions.") }}</li>
+    </ul>
+  </div>


### PR DESCRIPTION
 Make the contact form's JS bundle configurable via OVERRIDE_, so each instance can switch it on or leave it off, and drop the old inline Zammad code from theme.js.

Link to PR; https://github.com/tu-graz-library/invenio-config-tugraz/pull/164  commit: [296bd28](https://github.com/tu-graz-library/invenio-config-tugraz/pull/164/commits/296bd287dac41903996a1a67edd90e0d365dc176)